### PR TITLE
Fallback to 'clean' if rule fclean throws exception in makefile

### DIFF
--- a/src/build_systems.rs
+++ b/src/build_systems.rs
@@ -52,17 +52,15 @@ impl BuildSystems {
                 let command = Command::new("make")
                     .arg("fclean")
                     .envs(shared::DEFAULT_RUN_ENV)
-                    .spawn()?
-                    .wait_with_output();
+                    .status()?;
 
-                if !command.unwrap().status.success() {
+                if !command.success() {
                     println!("Error: Could not run rule 'fclean', trying 'clean'");
-                    let command_fallback = Command::new("make")
+                    let command = Command::new("make")
                         .arg("clean")
                         .envs(shared::DEFAULT_RUN_ENV)
-                        .spawn()?
-                        .wait_with_output();
-                    if !command_fallback.unwrap().status.success() {
+                        .status()?;
+                    if !command.success() {
                         println!("Error: Could not run rule 'clean', continuing...");
                     }
                 }


### PR DESCRIPTION
j'ai pas mit 're' pcq ça aurait pas de sens de clean en utilisant 're' si on recompile nous même après