### PR TITLE
Now ignores the files in the ignored directories

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -270,8 +270,7 @@ fn verify_ignore(errors: &mut Vec<LineError>) -> Result<(), Error> {
             if ignored_file.is_empty() {
                 continue;
             } else if error.file == ignored_file
-                || ignored_file.ends_with('/')
-                    && error.file.starts_with(&ignored_file)
+                || ignored_file.ends_with('/') && error.file.starts_with(&ignored_file)
             {
                 error.ignore = true;
             }


### PR DESCRIPTION
## Before:
[.gitignore]
``test/``
*shows errors for files in test/*

## Now:
*ignores the error*

W cs2 ❤️‍🩹

Closes #29 